### PR TITLE
Update futures dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.39"
 bzip2 = { version = "0.4", optional = true }
 flate2 = { version = "1.0.16", optional = true }
 fs2 = { version = "0.4", optional = true }
-itertools = { version = "0.8", optional = true }
+itertools = { version = "0.13", optional = true }
 lz4 = { version = "1.23", optional = true }
 lz-fear = { version = "0.1.1", optional = true }
 ndarray = { version = "0.13", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ filesystem = ["fs2", "walkdir"]
 gzip = ["flate2"]
 lz = ["lz4"]
 lz_pure = ["lz-fear"]
-use_ndarray = ["itertools", "ndarray", "num-traits"]
+use_ndarray = ["ndarray", "num-traits"]
 xz = ["xz2"]
 jpeg = ["zune-jpeg"]
 
@@ -30,7 +30,7 @@ serde_json = "1.0.39"
 bzip2 = { version = "0.4", optional = true }
 flate2 = { version = "1.0.16", optional = true }
 fs2 = { version = "0.4", optional = true }
-itertools = { version = "0.13", optional = true }
+itertools = "0.13"
 lz4 = { version = "1.23", optional = true }
 lz-fear = { version = "0.1.1", optional = true }
 ndarray = { version = "0.13", optional = true }
@@ -45,7 +45,7 @@ jpeg-decoder = "0.3.1"
 jpeg-encoder = "0.6.0"
 lru = "0.12.3"
 murmur3 = "0.5.2"
-futures = "0.1.29"
+futures = "0.3"
 
 [dependencies.web-sys]
 version = "0.3"
@@ -54,7 +54,7 @@ features = [ "console" ]
 [dev-dependencies]
 bencher = "0.1.5"
 doc-comment = "0.3"
-futures = "0.1"
+futures = "0.3"
 futures-cpupool = "0.1.8"
 lazy_static = "1.4"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ jpeg-decoder = "0.3.1"
 jpeg-encoder = "0.6.0"
 lru = "0.12.3"
 murmur3 = "0.5.2"
-itertools = "0.13"
 futures = "0.1.29"
 
 [dependencies.web-sys]


### PR DESCRIPTION
Update the futures dependency from `0.1` to `0.3`.

Notable changes are:
- Functions/methods returning `Box<dyn Future<Item = T>>` now uses Rust **async/await** syntax to automatically wrap the return value into a Future.
- Commented out `get_data` and `exists` method to get the code to compile.