### PR TITLE
Add rust-toolchain config file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt", "rustc-dev" ]


### PR DESCRIPTION
Instead of manually setting the rust toolchain to nightly, the `rust-toolchain.tom` file will automatically default to the latest nightly version of the rust compiler.