### PR TITLE
Refactor filesystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["encoding", "filesystem", "science"]
 default = ["bzip", "filesystem", "gzip", "lz", "use_ndarray", "xz", "jpeg"]
 
 bzip = ["bzip2"]
-filesystem = ["fs2", "walkdir"]
+filesystem = []
 gzip = ["flate2"]
 lz = ["lz4"]
 lz_pure = ["lz-fear"]
@@ -29,7 +29,6 @@ serde_json = "1.0.39"
 
 bzip2 = { version = "0.4", optional = true }
 flate2 = { version = "1.0.16", optional = true }
-fs2 = { version = "0.4", optional = true }
 itertools = "0.13"
 lz4 = { version = "1.23", optional = true }
 lz-fear = { version = "0.1.1", optional = true }
@@ -37,7 +36,6 @@ ndarray = { version = "0.13", optional = true }
 num-traits = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 smallvec = { version = "1", features = ["serde"] }
-walkdir = { version = "2", optional = true }
 xz2 = { version = "0.1", optional = true }
 zune-jpeg = { version = "0.4.11", optional = true }
 zune-core = "0.4.12"

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -93,7 +93,7 @@ impl NgPreFilesystem {
                     "Path name is outside this NgPre filesystem on a prefix path")),
                 Some(Component::RootDir) => (),
                 // This should be unreachable.
-                _ => return Err(Error::new(ErrorKind::NotFound, "Path is malformed")),
+                _ => return Err(Error::new(ErrorKind::Other, "Path is malformed")),
             }
         }
         let unrooted_path = components.as_path();

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -5,9 +5,7 @@ use std::io::{BufReader, BufWriter, Error, ErrorKind, Read, Result, Seek, SeekFr
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use fs2::FileExt;
 use serde_json::{self, json, Value};
-use walkdir::WalkDir;
 
 use crate::{
   is_version_compatible, DataBlock, DataBlockMetadata, DatasetAttributes, DefaultBlockReader,
@@ -281,7 +279,6 @@ impl NgPreWriter for NgPreFilesystem {
             .write(true)
             .create(true)
             .open(self.get_attributes_path(path_name)?)?;
-        file.lock_exclusive()?;
 
         let mut existing_buf = String::new();
         file.read_to_string(&mut existing_buf)?;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -69,7 +69,6 @@ impl NgPreFilesystem {
 
             if attr_path.exists() && attr_path.is_file() {
                 let file = File::open(attr_path)?;
-                file.lock_shared()?;
                 let reader = BufReader::new(file);
                 return Ok(serde_json::from_reader(reader)?)
             }
@@ -181,7 +180,6 @@ impl NgPreReader for NgPreFilesystem {
         let block_file = self.get_data_block_path(path_name, &grid_position)?;
         if block_file.is_file() {
             let file = File::open(block_file)?;
-            file.lock_shared()?;
             let reader = BufReader::new(file);
             Ok(Some(<crate::DefaultBlock as DefaultBlockReader<T, _>>::read_block(
                 reader,
@@ -202,7 +200,6 @@ impl NgPreReader for NgPreFilesystem {
         let block_file = self.get_data_block_path(path_name, &grid_position)?;
         if block_file.is_file() {
             let file = File::open(block_file)?;
-            file.lock_shared()?;
             let reader = BufReader::new(file);
             <crate::DefaultBlock as DefaultBlockReader<T, _>>::read_block_into(
                 reader,
@@ -239,7 +236,6 @@ impl NgPreReader for NgPreFilesystem {
     fn list_attributes(&self, path_name: &str) -> Result<Value> {
         let attr_path = self.get_attributes_path(path_name)?;
         let file = File::open(attr_path)?;
-        file.lock_shared()?;
         let reader = BufReader::new(file);
         Ok(serde_json::from_reader(reader)?)
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -75,7 +75,7 @@ impl NgPreFilesystem {
         Ok(reader)
     }
 
-    /// Open an existing NgPre container by path or create one if none exists.
+    /// Open an existing NgPre container by path or create one if not exists.
     ///
     /// Note this will update the version attribute for existing containers.
     pub fn open_or_create<P: AsRef<std::path::Path>>(base_path: P) -> Result<NgPreFilesystem> {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -339,16 +339,11 @@ impl NgPreWriter for NgPreFilesystem {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(path)?;
-        file.lock_exclusive()?;
-        // Truncate after the lock is acquired, rather than on opening.
-        file.set_len(0)?;
 
         let buffer = BufWriter::new(file);
-        <crate::DefaultBlock as DefaultBlockWriter<T, _, _>>::write_block(
-                buffer,
-                data_attrs,
-                block)
+        crate::DefaultBlock::write_block(buffer, data_attrs, block)
     }
 
     fn delete_block(

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -7,10 +7,10 @@ use std::str::FromStr;
 
 use serde_json::{self, json, Value};
 
+use crate::prelude::*;
 use crate::{
-  is_version_compatible, DataBlock, DataBlockMetadata, DatasetAttributes, DefaultBlockReader,
-  DefaultBlockWriter, GridCoord, NgPreLister, NgPreReader, NgPreWriter, ReadableDataBlock,
-  ReflectedType, ReinitDataBlock, VecDataBlock, Version, WriteableDataBlock,
+  is_version_compatible, DefaultBlockReader, DefaultBlockWriter, ReadableDataBlock,
+  ReinitDataBlock, Version, WriteableDataBlock,
 };
 
 /// Name of the attributes file stored in the container root and dataset dirs.

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -151,9 +151,10 @@ impl NgPreReader for NgPreFilesystem {
         Ok(serde_json::from_reader(reader)?)
     }
 
-    fn exists(&self, path_name: &str) -> Result<bool> {
-        let target = self.get_path(path_name)?;
-        Ok(target.is_dir())
+    /// Check if `PATH` exists for NGPRE dataset
+    fn exists(&self, path: &str) -> Result<bool> {
+        let target = self.get_path(path)?;
+        target.try_exists()
     }
 
     fn get_block_uri(&self, path_name: &str, grid_position: &[u64]) -> Result<String> {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -45,7 +45,7 @@ impl NgPreFilesystem {
     /// Open an existing NgPre container by path or create one if not exists.
     ///
     /// Note this will update the version attribute for existing containers.
-    pub fn open_or_create<P: AsRef<std::path::Path>>(base_path: P) -> Result<NgPreFilesystem> {
+    pub fn open_or_create<P: AsRef<Path>>(base_path: P) -> Result<NgPreFilesystem> {
         let reader = NgPreFilesystem {
             base_path: PathBuf::from(base_path.as_ref()),
         };
@@ -63,6 +63,7 @@ impl NgPreFilesystem {
 
     pub fn get_attributes(&self, path_name: &str) -> Result<Value> {
         let path = self.get_path(path_name)?;
+
         if path.is_dir() {
             let attr_path = path.join(ATTRIBUTES_FILE);
 
@@ -70,13 +71,13 @@ impl NgPreFilesystem {
                 let file = File::open(attr_path)?;
                 file.lock_shared()?;
                 let reader = BufReader::new(file);
-                Ok(serde_json::from_reader(reader)?)
-            } else {
-                Ok(json!({}))
+                return Ok(serde_json::from_reader(reader)?)
             }
-        } else {
-            Err(Error::new(ErrorKind::NotFound, "Path does not exist"))
+
+            return Err(Error::new(ErrorKind::Other, "File either doesn't exists or not a file"))
         }
+
+        return Err(Error::new(ErrorKind::NotADirectory, "Path is not a directory"))
     }
 
     /// Get the filesystem path for a given NgPre data path.

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -173,19 +173,18 @@ impl NgPreReader for NgPreFilesystem {
         data_attrs: &DatasetAttributes,
         grid_position: GridCoord,
     ) -> Result<Option<VecDataBlock<T>>>
-            where VecDataBlock<T>: DataBlock<T> + ReadableDataBlock,
-                  T: ReflectedType {
+    where
+        VecDataBlock<T>: DataBlock<T> + ReadableDataBlock,
+        T: ReflectedType
+    {
         let block_file = self.get_data_block_path(path_name, &grid_position)?;
         if block_file.is_file() {
             let file = File::open(block_file)?;
             let reader = BufReader::new(file);
-            Ok(Some(<crate::DefaultBlock as DefaultBlockReader<T, _>>::read_block(
-                reader,
-                data_attrs,
-                grid_position)?))
-        } else {
-            Ok(None)
+            return Ok(Some(crate::DefaultBlock::read_block(reader, data_attrs, grid_position)?))
         }
+
+        Ok(None)
     }
 
     fn read_block_into<T: ReflectedType, B: DataBlock<T> + ReinitDataBlock<T> + ReadableDataBlock>(

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -198,15 +198,11 @@ impl NgPreReader for NgPreFilesystem {
         if block_file.is_file() {
             let file = File::open(block_file)?;
             let reader = BufReader::new(file);
-            <crate::DefaultBlock as DefaultBlockReader<T, _>>::read_block_into(
-                reader,
-                data_attrs,
-                grid_position,
-                block)?;
-            Ok(Some(()))
-        } else {
-            Ok(None)
+            crate::DefaultBlock::read_block_into(reader, data_attrs, grid_position, block)?;
+            return Ok(Some(()))
         }
+
+        Ok(None)
     }
 
     fn block_metadata(

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -310,20 +310,7 @@ impl NgPreWriter for NgPreFilesystem {
         path_name: &str,
     ) -> Result<()> {
         let path = self.get_path(path_name)?;
-
-        for entry in WalkDir::new(path).contents_first(true) {
-            let entry = entry?;
-
-            if entry.file_type().is_dir() {
-                fs::remove_dir(entry.path())?;
-            } else {
-                let file = File::open(entry.path())?;
-                file.lock_exclusive()?;
-                fs::remove_file(entry.path())?;
-            }
-        }
-
-        Ok(())
+        fs::remove_dir_all(path)
     }
 
     fn write_block<T: ReflectedType, B: DataBlock<T> + WriteableDataBlock>(
@@ -354,10 +341,6 @@ impl NgPreWriter for NgPreFilesystem {
         let path = self.get_data_block_path(path_name, grid_position)?;
 
         if path.exists() {
-            let file = fs::OpenOptions::new()
-                .read(true)
-                .open(&path)?;
-            file.lock_exclusive()?;
             fs::remove_file(&path)?;
         }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,7 +1,7 @@
 //! A filesystem-backed NgPre container.
 
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Error, ErrorKind, Read, Result, Seek, SeekFrom};
+use std::io::{self, BufReader, BufWriter, Error, ErrorKind, Read, Result, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -51,13 +51,13 @@ impl NgPreFilesystem {
         };
 
         fs::create_dir_all(base_path)?;
+        let version = reader.get_version()?;
 
-        if reader.get_version().map(|v| !is_version_compatible(&crate::VERSION, &v)).unwrap_or(false) {
+        if !is_version_compatible(&crate::VERSION, &version) {
             return Err(Error::new(ErrorKind::Other, "TODO: Incompatible version"))
-        } else {
-            reader.set_attribute("", crate::VERSION_ATTRIBUTE_KEY.to_owned(), crate::VERSION.to_string())?;
         }
 
+        reader.set_attribute("", crate::VERSION_ATTRIBUTE_KEY.to_string(), crate::VERSION.to_string())?;
         Ok(reader)
     }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -246,21 +246,17 @@ impl NgPreReader for NgPreFilesystem {
 
 impl NgPreLister for NgPreFilesystem {
     fn list(&self, path_name: &str) -> Result<Vec<String>> {
-        // TODO: shouldn't do this in a closure to not equivocate errors with Nones.
-        Ok(fs::read_dir(self.get_path(path_name)?)?
-            .filter_map(|e| {
-                if let Ok(file) = e {
-                    if fs::metadata(file.path()).map(|f| f.file_type().is_dir()).ok() == Some(true) {
-                        file.file_name().into_string().ok()
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect()
-        )
+        let dir_reader = fs::read_dir(self.get_path(path_name)?)?;
+        let mut dir_names: Vec<String> = Vec::new();
+
+        for dir in dir_reader {
+            let dir = dir?;
+            if dir.path().is_dir() {
+                dir_names.push(dir.file_name().to_str().unwrap_or_default().to_string());
+            }
+        }
+
+        Ok(dir_names)
     }
 }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,55 +1,22 @@
 //! A filesystem-backed NgPre container.
 
-use std::fs::{
-    self,
-    File,
-};
-use std::io::{
-    Error,
-    ErrorKind,
-    BufReader,
-    BufWriter,
-    Read,
-    Result,
-    Seek,
-    SeekFrom,
-};
-use std::path::{
-    PathBuf,
-};
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Error, ErrorKind, Read, Result, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use fs2::FileExt;
-use serde_json::{
-    self,
-    json,
-    Value,
-};
+use serde_json::{self, json, Value};
 use walkdir::WalkDir;
 
 use crate::{
-    is_version_compatible,
-    DataBlock,
-    DataBlockMetadata,
-    DatasetAttributes,
-    DefaultBlockReader,
-    DefaultBlockWriter,
-    GridCoord,
-    NgPreLister,
-    NgPreReader,
-    NgPreWriter,
-    ReadableDataBlock,
-    ReflectedType,
-    ReinitDataBlock,
-    VecDataBlock,
-    Version,
-    WriteableDataBlock,
+  is_version_compatible, DataBlock, DataBlockMetadata, DatasetAttributes, DefaultBlockReader,
+  DefaultBlockWriter, GridCoord, NgPreLister, NgPreReader, NgPreWriter, ReadableDataBlock,
+  ReflectedType, ReinitDataBlock, VecDataBlock, Version, WriteableDataBlock,
 };
-
 
 /// Name of the attributes file stored in the container root and dataset dirs.
 const ATTRIBUTES_FILE: &str = "attributes.json";
-
 
 /// A filesystem-backed NgPre container.
 #[derive(Clone, Debug)]
@@ -59,7 +26,7 @@ pub struct NgPreFilesystem {
 
 impl NgPreFilesystem {
     /// Open an existing NgPre container by path.
-    pub fn open<P: AsRef<std::path::Path>>(base_path: P) -> Result<NgPreFilesystem> {
+    pub fn open<P: AsRef<Path>>(base_path: P) -> Result<NgPreFilesystem> {
         let reader = NgPreFilesystem {
             base_path: PathBuf::from(base_path.as_ref()),
         };


### PR DESCRIPTION
## Refactoring filesystem module

This PR includes small bug fixes and couple of improvements in the `filesystem.rs` module. There were some other places that can be improved but that would introduce breaking changes into the library API.

There is one notable change which is the `filesystem` module was locking the files for reading and writing using RUST *nightly* feature. Because this library doesn't perform any multithreaded or Async tasks there is not need for it, it just overhead and doesn't provide any benefits. Because of this the `fs2` dependency is no longer needed.

Other small changes:

- The `remove` method for `NgPreFileSystem` was deleting the directory in a inefficient way, by walking the directory and deleting every files/directory which introduce a new dependency `walkdir`. Instead deleting the parent directory does the job done in less lines of code and faster.
[commit](https://github.com/Hamza12700/rust-ngpre/commit/5c5bebc6a501adfbf1ba33275ba7d3802d4aec48#diff-cc568527f557020b58730f91eefeb6a0c39c04e606fe41c57e08ca16059e0852L314)

- To call any method on the `DefaultBlock` Type, it was being casted to another Type that implements that functions which is completely pointless because the `DefaultBlock` already implements those functions. [src/lib.rs](https://github.com/Hamza12700/rust-ngpre/blob/main/src/lib.rs#L693)
[commit](https://github.com/Hamza12700/rust-ngpre/commit/e4c31ac493703583148f80f517b8f288764b94a9#diff-cc568527f557020b58730f91eefeb6a0c39c04e606fe41c57e08ca16059e0852L348)
